### PR TITLE
Remove web nav logging

### DIFF
--- a/addon/webextension/background.js
+++ b/addon/webextension/background.js
@@ -82,7 +82,7 @@ function triggerPopup() {
 }
 
 function webNavListener(webNavInfo) {
-  console.log("webNavListener - webNavInfo:", webNavInfo);
+  // console.log("webNavListener - webNavInfo:", webNavInfo);
   webNavListener_trackDiscoPaneLoading(webNavInfo);
   webNavListener_popupRelated(webNavInfo);
 }
@@ -119,7 +119,7 @@ function webNavListener_popupRelated(webNavInfo) {
         }).then(
           function(updatedClientStatus) {
 
-            console.log("TotalURI: " + updatedClientStatus.totalWebNav);
+            // console.log("TotalURI: " + updatedClientStatus.totalWebNav);
 
             if ((!updatedClientStatus.sawPopup && updatedClientStatus.totalWebNav <= 3) || forcePopup) { // client has not seen popup
               // arbitrary condition for now
@@ -184,13 +184,13 @@ class TAARExperiment {
   }
 
   static monitorNavigation() {
-    console.log("Monitoring navigation to be able to show popup after 3 page visits");
+    // console.log("Monitoring navigation to be able to show popup after 3 page visits");
     browser.webNavigation.onCompleted.addListener(webNavListener,
       { url: [{ schemes: ["http", "https"] }] });
   }
 
   static notifyStudyEverySecondAboutAddonsIsTheActiveTabUrl() {
-    console.log("Checking the active tab every second to be able to increment aboutAddonsActiveTabSeconds");
+    // console.log("Checking the active tab every second to be able to increment aboutAddonsActiveTabSeconds");
 
     const interval = 1000;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "taarexpv2",
   "description": "TAAR Experiment v2 Shield Study",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "author": "Fredrik Wollsén <fwollsen@mozilla.com>",
   "addon": {
     "ABOUT": "use these variables fill the moustache templates",


### PR DESCRIPTION
Removes logging that is displayed after each web navigation along with some other unnecessary log output. 

* 4 `console.log()` statements were commented out in `background.js`
* Version was incremented to 1.0.3 in `package.json`